### PR TITLE
fixed bug where usage example would always throw `IllegalArgumentExce…

### DIFF
--- a/src/main/java/io/github/antonschnfeld/Main.java
+++ b/src/main/java/io/github/antonschnfeld/Main.java
@@ -17,7 +17,7 @@ public class Main {
 
         ecs.destroyEntity(entity);
 
-        System.out.println("Destroyed: " + EntityUtil.toString(entity) + ": " + ecs.getComponents(entity));
+        System.out.println("Destroyed: " + EntityUtil.toString(entity));
 
         entity = ecs.createEntity(2, 3, "Different Components");
 

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/EntityWorldImpl.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/EntityWorldImpl.java
@@ -1,6 +1,5 @@
 package io.github.antonschnfeld.drakon.ecs;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class EntityWorldImpl implements EntityWorld {


### PR DESCRIPTION
- Addressed issue https://github.com/AntonSchnfeld/drakon-ecs/issues/4 by removing the component array of the destroyed entity from the print statement
- chores: removed an unnecessary import in `EntityWorldImpl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified destruction log output to only include the entity, reducing noise and preventing potential errors when logging destroyed entities.

* **Chores**
  * Removed an unused import to clean up the codebase with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->