### PR TITLE
fixed test createManyEntityWithComponents_thenEntitiesHaveComponents

### DIFF
--- a/src/main/java/io/github/antonschnfeld/Main.java
+++ b/src/main/java/io/github/antonschnfeld/Main.java
@@ -17,7 +17,7 @@ public class Main {
 
         ecs.destroyEntity(entity);
 
-        System.out.println("Destroyed: " + EntityUtil.toString(entity) + ": " + ecs.getComponents(entity));
+        System.out.println("Destroyed: " + EntityUtil.toString(entity));
 
         entity = ecs.createEntity(2, 3, "Different Components");
 

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/EntityWorldImpl.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/EntityWorldImpl.java
@@ -1,6 +1,5 @@
 package io.github.antonschnfeld.drakon.ecs;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class EntityWorldImpl implements EntityWorld {

--- a/src/test/java/io/github/antonschnfeld/ecs/EntityWorldTest.java
+++ b/src/test/java/io/github/antonschnfeld/ecs/EntityWorldTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 abstract class EntityWorldTest {
     private static final int MANY = 100_000;
 
@@ -99,7 +101,7 @@ abstract class EntityWorldTest {
         for (int i = 0; i < entities.length; i++) {
             Assertions.assertTrue(ecs.isEntityAlive(entities[i]));
 
-            Assertions.assertArrayEquals(new Object[]{stringComponent, i}, ecs.getComponents(entities[i]).toArray());
+            Assertions.assertIterableEquals(Arrays.asList(stringComponent, i), ecs.getComponents(entities[i]));
 
             Assertions.assertEquals(stringComponent, ecs.getComponent(entities[i], String.class));
             Assertions.assertEquals(i, ecs.getComponent(entities[i], Integer.class));

--- a/src/test/java/io/github/antonschnfeld/ecs/EntityWorldTest.java
+++ b/src/test/java/io/github/antonschnfeld/ecs/EntityWorldTest.java
@@ -81,7 +81,7 @@ abstract class EntityWorldTest {
         long entity = Assertions.assertDoesNotThrow(() -> ecs.createEntity(components));
         Assertions.assertTrue(ecs.isEntityAlive(entity));
 
-        Assertions.assertArrayEquals(components, ecs.getComponents(entity).toArray());
+        Assertions.assertIterableEquals(Arrays.asList(components), ecs.getComponents(entity));
 
         Assertions.assertEquals(components[0], ecs.getComponent(entity, String.class));
         Assertions.assertEquals(components[1], ecs.getComponent(entity, Integer.class));
@@ -114,7 +114,7 @@ abstract class EntityWorldTest {
         Assertions.assertTrue(ecs.isEntityAlive(entity));
         Assertions.assertDoesNotThrow(() -> ecs.removeComponent(entity, String.class));
         Assertions.assertNull(ecs.getComponent(entity, String.class));
-        Assertions.assertArrayEquals(new Object[0], ecs.getComponents(entity).toArray());
+        Assertions.assertTrue(ecs.getComponents(entity).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
- fixed bug where test was wrongfully testing the order of the returned components as addressed by https://github.com/AntonSchnfeld/drakon-ecs/issues/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined unit tests to use iterable-aware comparisons for component lists.
  * More explicit validation of component ordering to catch regressions earlier.
  * Improves test reliability and reduces flakiness across environments.
  * No changes to runtime behavior or public APIs; end users should not notice any difference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->