### PR TITLE
Added `BooleanComponent`, `DoubleComponent`, `FloatComponent`, `IntCo…

### DIFF
--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/BooleanComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/BooleanComponent.java
@@ -1,0 +1,27 @@
+package io.github.antonschnfeld.drakon.ecs.primitive;
+
+public interface BooleanComponent extends PrimitiveComponent {
+    void add(long entity, boolean b1);
+
+    void add(long entity, boolean b1, boolean b2);
+
+    void add(long entity, boolean b1, boolean b2, boolean b3);
+
+    void add(long entity, boolean b1, boolean b2, boolean b3, boolean b4);
+
+    void add(long entity, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5);
+
+    void add(long entity, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5, boolean b6);
+
+    void add(long entity, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5, boolean b6, boolean b7);
+
+    void add(long entity, boolean b1, boolean b2, boolean b3, boolean b4, boolean b5, boolean b6, boolean b7, boolean b8);
+
+    void add(long entity, boolean... booleans);
+
+    boolean get(long entity, int index);
+
+    boolean[] get(long entity);
+
+    void get(long entity, boolean[] booleans);
+}

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/BooleanComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/BooleanComponent.java
@@ -21,7 +21,7 @@ public interface BooleanComponent extends PrimitiveComponent {
 
     boolean get(long entity, int index);
 
-    boolean[] get(long entity);
-
     void get(long entity, boolean[] booleans);
+
+    boolean[] get(long entity);
 }

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/DoubleComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/DoubleComponent.java
@@ -1,0 +1,27 @@
+package io.github.antonschnfeld.drakon.ecs.primitive;
+
+public interface DoubleComponent extends PrimitiveComponent {
+    void add(long entity, double d1);
+
+    void add(long entity, double d1, double d2);
+
+    void add(long entity, double d1, double d2, double d3);
+
+    void add(long entity, double d1, double d2, double d3, double d4);
+
+    void add(long entity, double d1, double d2, double d3, double d4, double d5);
+
+    void add(long entity, double d1, double d2, double d3, double d4, double d5, double d6);
+
+    void add(long entity, double d1, double d2, double d3, double d4, double d5, double d6, double d7);
+
+    void add(long entity, double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8);
+
+    void add(long entity, double... doubles);
+
+    double get(long entity, int index);
+
+    void get(long entity, double[] doubles);
+
+    double[] get(long entity);
+}

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/FloatComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/FloatComponent.java
@@ -1,0 +1,27 @@
+package io.github.antonschnfeld.drakon.ecs.primitive;
+
+public interface FloatComponent extends PrimitiveComponent {
+    void add(long entity, float f1);
+
+    void add(long entity, float f1, float f2);
+
+    void add(long entity, float f1, float f2, float f3);
+
+    void add(long entity, float f1, float f2, float f3, float f4);
+
+    void add(long entity, float f1, float f2, float f3, float f4, float f5);
+
+    void add(long entity, float f1, float f2, float f3, float f4, float f5, float f6);
+
+    void add(long entity, float f1, float f2, float f3, float f4, float f5, float f6, float f7);
+
+    void add(long  entity, float f1, float f2, float f3, float f4, float f5, float f6, float f7, float f8);
+
+    void add(long entity, float... floats);
+
+    float get(long entity, int index);
+
+    float[] get(long entity);
+
+    void get(long entity, float[] floats);
+}

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/FloatComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/FloatComponent.java
@@ -21,7 +21,7 @@ public interface FloatComponent extends PrimitiveComponent {
 
     float get(long entity, int index);
 
-    float[] get(long entity);
-
     void get(long entity, float[] floats);
+
+    float[] get(long entity);
 }

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/IntComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/IntComponent.java
@@ -1,0 +1,27 @@
+package io.github.antonschnfeld.drakon.ecs.primitive;
+
+public interface IntComponent extends PrimitiveComponent {
+    void add(long entity, int i1);
+
+    void add(long entity, int i1, int i2);
+
+    void add(long entity, int i1, int i2, int i3);
+
+    void add(long entity, int i1, int i2, int i3, int i4);
+
+    void add(long entity, int i1, int i2, int i3, int i4, int i5);
+
+    void add(long entity, int i1, int i2, int i3, int i4, int i5, int i6);
+
+    void add(long entity, int i1, int i2, int i3, int i4, int i5, int i6, int i7);
+
+    void add(long entity, int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8);
+
+    void add(long entity, int... ints);
+
+    int get(long entity, int index);
+
+    int[] get(long entity);
+
+    void get(long entity, int[] ints);
+}

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/IntComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/IntComponent.java
@@ -21,7 +21,7 @@ public interface IntComponent extends PrimitiveComponent {
 
     int get(long entity, int index);
 
-    int[] get(long entity);
-
     void get(long entity, int[] ints);
+
+    int[] get(long entity);
 }

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/LongComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/LongComponent.java
@@ -1,0 +1,27 @@
+package io.github.antonschnfeld.drakon.ecs.primitive;
+
+public interface LongComponent extends PrimitiveComponent {
+    void add(long entity, long l1);
+
+    void add(long entity, long l1, long l2);
+
+    void add(long entity, long l1, long l2, long l3);
+
+    void add(long entity, long l1, long l2, long l3, long l4);
+
+    void add(long entity, long l1, long l2, long l3, long l4, long l5);
+
+    void add(long entity, long l1, long l2, long l3, long l4, long l5, long l6);
+
+    void add(long entity, long l1, long l2, long l3, long l4, long l5, long l6, long l7);
+
+    void add(long entity, long l1, long l2, long l3, long l4, long l5, long l6, long l7, long l8);
+
+    void add(long entity, long... longs);
+
+    long get(long entity, int index);
+
+    void get(long entity, long[] longs);
+
+    long[] get(long entity);
+}

--- a/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/PrimitiveComponent.java
+++ b/src/main/java/io/github/antonschnfeld/drakon/ecs/primitive/PrimitiveComponent.java
@@ -1,0 +1,9 @@
+package io.github.antonschnfeld.drakon.ecs.primitive;
+
+import io.github.antonschnfeld.drakon.ecs.EntityWorld;
+
+public interface PrimitiveComponent {
+    int getId();
+
+    EntityWorld getWorld();
+}


### PR DESCRIPTION
Added `BooleanComponent`, `DoubleComponent`, `FloatComponent`, `IntComponent`, `LongComponent` and `PrimitiveComponent`

- `PrimitiveComponent` is the base interface for all component interfaces that represent a component type makeup of a primitive type

- `XXXComponent` all extend `PrimitiveComponent`
- Provide 9 overloads for the `add` method, the first 8 allowing up to 8 arguments and the last accepting a var args argument for scalability
- Also provide get methods for getting a primitive value from an entity with the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed primitive components for booleans, doubles, floats, ints, and longs in the ECS.
  * Each component supports adding multiple values per entity (single, fixed-size up to several values, or variable-length) and retrieving values by index or as arrays.
  * Introduced a common primitive component interface exposing component identity and world access for consistent usage across types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->